### PR TITLE
initialDate should be more important

### DIFF
--- a/js/bootstrap-datetimepicker.js
+++ b/js/bootstrap-datetimepicker.js
@@ -380,7 +380,7 @@
 				date = arguments[0];
 				fromArgs = true;
 			} else {
-				date = this.isInput ? this.element.prop('value') : this.element.data('date') || this.element.find('input').prop('value') || this.initialDate;
+				date = (this.isInput ? this.element.prop('value') : this.element.data('date') || this.element.find('input').prop('value')) || this.initialDate;
 			}
 
 			if (!date) {


### PR DESCRIPTION
For example: if element is input then initialDate is ignored. This is a quick fix.
