### PR TITLE
Modify all access to input element values to use the $.fn.val()

### DIFF
--- a/js/bootstrap-datetimepicker.js
+++ b/js/bootstrap-datetimepicker.js
@@ -308,11 +308,11 @@
 			var formatted = this.getFormattedDate();
 			if (!this.isInput) {
 				if (this.component){
-					this.element.find('input').prop('value', formatted);
+					this.element.find('input').val(formatted);
 				}
 				this.element.data('date', formatted);
 			} else {
-				this.element.prop('value', formatted);
+				this.element.val(formatted);
 			}
 			if (this.linkField) {
 				$('#' + this.linkField).val(this.getFormattedDate(this.linkFormat));
@@ -388,7 +388,7 @@
 				date = arguments[0];
 				fromArgs = true;
 			} else {
-				date = (this.isInput ? this.element.prop('value') : this.element.data('date') || this.element.find('input').prop('value')) || this.initialDate;
+				date = (this.isInput ? this.element.val() : this.element.data('date') || this.element.find('input').val()) || this.initialDate;
 			}
 
 			if (!date) {


### PR DESCRIPTION
 JQuery's docs suggest the usage of val() to get/set a value of an input.  Using prop goes against this expectation which many other plugins follow and as such breaks this plugins compatibility with them
