### PR TITLE
Fix formatDate: show the last index of separators

### DIFF
--- a/js/bootstrap-datetimepicker.js
+++ b/js/bootstrap-datetimepicker.js
@@ -1388,9 +1388,13 @@
 			var date = [],
 				seps = $.extend([], format.separators);
 			for (var i=0, cnt = format.parts.length; i < cnt; i++) {
-				if (seps.length)
-					date.push(seps.shift())
+				if (seps.length) {
+					date.push(seps.shift());
+				}
 				date.push(val[format.parts[i]]);
+			}
+			if (seps.length) {
+				date.push(seps.shift());
 			}
 			return date.join('');
 		},


### PR DESCRIPTION
if there are some other string at the end of the format, like "yyyy-mm-dd hh:00" (the string ":00"), it will be shown as "2013-05-23 13", but it should be "2013-05-23 13:00"
