### PR TITLE
Selecting 'old' date results in incorrect date for some months

### DIFF
--- a/js/bootstrap-datetimepicker.js
+++ b/js/bootstrap-datetimepicker.js
@@ -1490,4 +1490,32 @@
 
 	$.fn.datetimepicker.DPGlobal = DPGlobal;
 
+
+	/* DATETIMEPICKER NO CONFLICT
+	* =================== */
+
+	$.fn.datetimepicker.noConflict = function () {
+	    $.fn.datetimepicker = old;
+	    return this;
+	};
+
+
+	/* DATETIMEPICKER DATA-API
+	* ================== */
+
+	$(document).on(
+		'focus.datetimepicker.data-api click.datetimepicker.data-api',
+		'[data-provide="datetimepicker"]',
+		function (e) {
+		    var $this = $(this);
+		    if ($this.data('datetimepicker')) return;
+		    e.preventDefault();
+		    // component click requires us to explicitly show it
+		    $this.datetimepicker('show');
+		}
+	);
+	$(function () {
+	    $('[data-provide="datetimepicker-inline"]').datetimepicker();
+	});
+
 }( window.jQuery );


### PR DESCRIPTION
When choosing an old date from the calendar, the date that is select is incorrect.
For example, if the current month is June and 31st of May is selected, the date is set to 1st of May. It occurs when the current month has more days than the previous month.
