### PR TITLE
add meridiem values to pt-BR

### DIFF
--- a/js/locales/bootstrap-datetimepicker.pt-BR.js
+++ b/js/locales/bootstrap-datetimepicker.pt-BR.js
@@ -11,6 +11,6 @@
 		monthsShort: ["Jan", "Fev", "Mar", "Abr", "Mai", "Jun", "Jul", "Ago", "Set", "Out", "Nov", "Dez"],
 		today: "Hoje",
 		suffix: [],
-		meridiem: []
+		meridiem: ['am', 'pm']
 	};
 }(jQuery));


### PR DESCRIPTION
It is causes a big problem when there is a language file without meridiem and you set the format for using mederians.  Without the translation it can end up selecting times 12 hours earlier than you expect.  For example, if you select 16:05 it will end up selecting 4:05.

The best solution for this would be to ignore merdian formatting when displaying in a language where meridiems aren't defined (not part of this pull request)
