### PR TITLE
stay in 24 format for H or HH if language does not have meridiem

### DIFF
--- a/js/bootstrap-datetimepicker.js
+++ b/js/bootstrap-datetimepicker.js
@@ -57,7 +57,7 @@
 				this.initialDate = options.initialDate || new Date();
 
 		this._attachEvents();
-		
+
 			this.formatViewType = "datetime";
 			if ('formatViewType' in options) {
 					this.formatViewType = options.formatViewType;
@@ -214,7 +214,7 @@
 				el.on(ev);
 			}
 		},
-		
+
 		_detachEvents: function(){
 			for (var i=0, el, ev; i<this._events.length; i++){
 				el = this._events[i][0];
@@ -257,7 +257,7 @@
 			if (
 				this.forceParse &&
 				(
-					this.isInput && this.element.val()  || 
+					this.isInput && this.element.val()  ||
 					this.hasInput && this.element.find('input').val()
 				)
 			)
@@ -473,7 +473,7 @@
 						this.picker.find('.datetimepicker-hours thead th:eq(1)')
 								.text(dayMonth + ' ' + dates[this.language].months[month] + ' ' + year);
 						this.picker.find('.datetimepicker-minutes thead th:eq(1)')
-								.text(dayMonth + ' ' + dates[this.language].months[month] + ' ' + year);		        
+								.text(dayMonth + ' ' + dates[this.language].months[month] + ' ' + year);
 				}
 				this.picker.find('tfoot th.today')
 						.text(dates[this.language].today)
@@ -631,7 +631,7 @@
 				hour = d.getUTCHours();
 			switch (this.viewMode) {
 				case 0:
-					if (this.startDate !== -Infinity && year <= this.startDate.getUTCFullYear() 
+					if (this.startDate !== -Infinity && year <= this.startDate.getUTCFullYear()
 													 && month <= this.startDate.getUTCMonth()
 													 && day <= this.startDate.getUTCDate()
 													 && hour <= this.startDate.getUTCHours()) {
@@ -639,7 +639,7 @@
 					} else {
 						this.picker.find('.prev').css({visibility: 'visible'});
 					}
-					if (this.endDate !== Infinity && year >= this.endDate.getUTCFullYear() 
+					if (this.endDate !== Infinity && year >= this.endDate.getUTCFullYear()
 													&& month >= this.endDate.getUTCMonth()
 													&& day >= this.endDate.getUTCDate()
 													&& hour >= this.endDate.getUTCHours()) {
@@ -649,14 +649,14 @@
 					}
 					break;
 				case 1:
-					if (this.startDate !== -Infinity && year <= this.startDate.getUTCFullYear() 
+					if (this.startDate !== -Infinity && year <= this.startDate.getUTCFullYear()
 													 && month <= this.startDate.getUTCMonth()
 													 && day <= this.startDate.getUTCDate()) {
 						this.picker.find('.prev').css({visibility: 'hidden'});
 					} else {
 						this.picker.find('.prev').css({visibility: 'visible'});
 					}
-					if (this.endDate !== Infinity && year >= this.endDate.getUTCFullYear() 
+					if (this.endDate !== Infinity && year >= this.endDate.getUTCFullYear()
 													&& month >= this.endDate.getUTCMonth()
 													&& day >= this.endDate.getUTCDate()) {
 						this.picker.find('.next').css({visibility: 'hidden'});
@@ -665,13 +665,13 @@
 					}
 					break;
 				case 2:
-					if (this.startDate !== -Infinity && year <= this.startDate.getUTCFullYear() 
+					if (this.startDate !== -Infinity && year <= this.startDate.getUTCFullYear()
 													 && month <= this.startDate.getUTCMonth()) {
 						this.picker.find('.prev').css({visibility: 'hidden'});
 					} else {
 						this.picker.find('.prev').css({visibility: 'visible'});
 					}
-					if (this.endDate !== Infinity && year >= this.endDate.getUTCFullYear() 
+					if (this.endDate !== Infinity && year >= this.endDate.getUTCFullYear()
 													&& month >= this.endDate.getUTCMonth()) {
 						this.picker.find('.next').css({visibility: 'hidden'});
 					} else {
@@ -1118,7 +1118,7 @@
 			this.picker.find('>div').hide().filter('.datetimepicker-'+DPGlobal.modes[this.viewMode].clsName).css('display', 'block');
 			this.updateNavArrows();
 		},
-		
+
 		reset: function(e) {
 			this._setDate(null, 'date');
 		}
@@ -1360,7 +1360,13 @@
 					// second
 					s: date.getUTCSeconds()
 				};
-								val.H  = (val.h%12==0? 12 : val.h%12);
+
+        if (dates[language].meridiem.length==2) {
+          val.H  = (val.h%12==0? 12 : val.h%12);
+        }
+        else {
+          val.H  = val.h;
+        }
 								val.HH = (val.H < 10 ? '0' : '') + val.H;
 								val.P  = val.p.toUpperCase();
 				val.hh = (val.h < 10 ? '0' : '') + val.h;

--- a/tests/suites/formats.js
+++ b/tests/suites/formats.js
@@ -72,6 +72,35 @@ test('yyyy: Year, four-digit.', function(){
     equal(this.input.val().split('-')[0], '2012');
 });
 
+test('H: 12 hour when language has meridiems', function(){
+    this.input
+        .val('2012-March-5 16:00:00')
+        .datetimepicker({format: 'yyyy-mm-dd H:ii p'})
+        .datetimepicker('setValue');
+    ok(this.input.val().match(/4:00 pm/));
+});
+
+test('H: 24 hour when language has no meridiems', function(){
+
+    $.fn.datetimepicker.dates['pt-BR'] = {
+      days: ["Domingo", "Segunda", "Terça", "Quarta", "Quinta", "Sexta", "Sábado", "Domingo"],
+      daysShort: ["Dom", "Seg", "Ter", "Qua", "Qui", "Sex", "Sáb", "Dom"],
+      daysMin: ["Do", "Se", "Te", "Qu", "Qu", "Se", "Sa", "Do"],
+      months: ["Janeiro", "Fevereiro", "Março", "Abril", "Maio", "Junho", "Julho", "Agosto", "Setembro", "Outubro", "Novembro", "Dezembro"],
+      monthsShort: ["Jan", "Fev", "Mar", "Abr", "Mai", "Jun", "Jul", "Ago", "Set", "Out", "Nov", "Dez"],
+      today: "Hoje",
+      suffix: [],
+      meridiem: []
+    };
+
+    this.input
+        .val('2012-March-5 16:00:00')
+        .datetimepicker({format: 'yyyy-mm-dd H:ii p', language: 'pt-BR'})
+        .datetimepicker('setValue');
+    ok(this.input.val().match(/16:00/));
+});
+
+
 test('dd-mm-yyyy: Regression: Prevent potential month overflow in small-to-large formats (Mar 31, 2012 -> Mar 01, 2012)', function(){
     this.input
         .val('31-03-2012')


### PR DESCRIPTION
Fixes problem if the format for the datepicker is set with "H" or "HH" and a language that does not have Meridiem is set.  Without this fix, times after 12:00 can't correctly be selected.  16:00 ends up appearing as 4:00.  This fix ensure that the hour stays in 24 format if the language doesn't have meridiem.  
