### PR TITLE
Added option to set default date format in the language settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -476,6 +476,15 @@ $.fn.datetimepicker.dates['en'] = {
 };
 ```
 
+You can override the default date format in the language configuration with `format` attribute.
+Example:
+
+```javascript
+$.fn.datetimepicker.dates['pt-BR'] = {
+    format: 'dd/mm/yyyy'
+};
+```
+
 Right-to-left languages may also include `rtl: true` to make the calendar display appropriately.
 
 If your browser (or those of your users) is displaying characters wrong, chances are the browser is loading the javascript file with a non-unicode encoding.  Simply add `charset="UTF-8"` to your `script` tag:

--- a/js/bootstrap-datetimepicker.js
+++ b/js/bootstrap-datetimepicker.js
@@ -39,7 +39,7 @@
 		this.language = this.language in dates ? this.language : "en";
 		this.isRTL = dates[this.language].rtl || false;
 		this.formatType = options.formatType || this.element.data('format-type') || 'standard';
-		this.format = DPGlobal.parseFormat(options.format || this.element.data('date-format') || DPGlobal.getDefaultFormat(this.formatType, 'input'), this.formatType);
+		this.format = DPGlobal.parseFormat(options.format || this.element.data('date-format') || dates[this.language].format || DPGlobal.getDefaultFormat(this.formatType, 'input'), this.formatType);
 		this.isInline = false;
 		this.isVisible = false;
 		this.isInput = this.element.is('input');

--- a/js/locales/bootstrap-datetimepicker.pt-BR.js
+++ b/js/locales/bootstrap-datetimepicker.pt-BR.js
@@ -4,6 +4,7 @@
  */
 ;(function($){
 	$.fn.datetimepicker.dates['pt-BR'] = {
+        format: 'dd/mm/yyyy',
 		days: ["Domingo", "Segunda", "Terça", "Quarta", "Quinta", "Sexta", "Sábado", "Domingo"],
 		daysShort: ["Dom", "Seg", "Ter", "Qua", "Qui", "Sex", "Sáb", "Dom"],
 		daysMin: ["Do", "Se", "Te", "Qu", "Qu", "Se", "Sa", "Do"],


### PR DESCRIPTION
Sometimes you need to specify the default date format in a broad scope, just added a minor change so the format can also be read from `dates[this.language].format` if exists.
