### PR TITLE
Fixed memory leak

### DIFF
--- a/js/bootstrap-datetimepicker.js
+++ b/js/bootstrap-datetimepicker.js
@@ -272,6 +272,7 @@
 		remove: function() {
 			this._detachEvents();
 			this.picker.remove();
+			delete this.picker;
 			delete this.element.data().datetimepicker;
 		},
 


### PR DESCRIPTION
Calling .datetimepicker("remove") wasn't dereferencing internal "picker" field, which is referencing DOM tree. This сaused DOM elements to be detached, but not released from memory.

Sample code to repro:

```
<!DOCTYPE html>
<html>
<body>
    <input id="dt-input" type="text" />
    <button id="btn-remove">Remove DateTime Picker</button>
    <script src="jquery.min.js"></script>
    <script src="bootstrap-datetimepicker.js"></script>
    <script>
        var $input = $("#dt-input"),
            $btn = $("#btn-remove");

        $input.datetimepicker();
        $btn.on("click", function(e) {
            e.preventDefault();
            $input.datetimepicker("remove");
            $input = null;
        });

    </script>
</body>
</html>
```

(Bootstrap and css are not referenced to make it as simple as possible)

Steps:
1. Open this html in chrome
2. Click 'Remove DateTime Picker' button.
3. Open chome's dev tools (F12) and navigate to the "Profiles" tab. 
4. Select Take Heap Snapshot and click Take Snapshot.
5, Once snapshot is generated switch to the Containment mode and analyze "Detached DOM trees" node.

![image](https://f.cloud.github.com/assets/798485/904000/774b2498-fbb9-11e2-8d1a-c3e098e3d30a.png)
