### PR TITLE
Documented optional argument to "update" method to set the current datetime.

### DIFF
--- a/README.md
+++ b/README.md
@@ -336,9 +336,17 @@ $('#datetimepicker').datetimepicker('hide');
 
 ### update
 
-Arguments: None
+Arguments: 
 
-Update the datetimepicker with the current input value.
+* currentDate (Date).
+
+Update the datetimepicker with the specified date.
+
+```javascript
+$('#datetimepicker').datetimepicker('update', new Date());
+```
+
+Omit currentDate to update the datetimepicker with the current input value.
 
 ```javascript
 $('#datetimepicker').datetimepicker('update');


### PR DESCRIPTION
The "update" method already supports an optional Date argument to set the datetimepicker to that value.

It is a better way to set the current time, since I can pass a native Date object and it will be correctly parsed.
