### PR TITLE
Custom arrow icons, custom trigger/reset element selectors

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,22 @@ As component:
 $('#datetimepicker').datetimepicker();
 ```
 
+As component (for Twitter Bootstrap 3):
+
+```html
+<div class="input-group date col-lg-3" id="datetimepicker" 
+    data-date="12-02-2012 12:10" data-date-format="dd-mm-yyyy hh:ii"
+    data-icon-prev="glyphicon glyphicon-chevron-left" data-icon-next="glyphicon glyphicon-chevron-right"
+    data-trigger-selector=".glyphicon-calendar" 
+    >
+    <input type="text" size="16" class="form-control" value="12-02-2012 12:10" readonly>
+    <span class="input-group-addon"><i class="glyphicon glyphicon-calendar"></i></span>
+</div>
+```
+```javascript
+$('#datetimepicker').datetimepicker();
+```
+
 As inline datetimepicker:
 
 ```html
@@ -282,6 +298,35 @@ You can initialize the viewer with a date. By default it's now, so you can speci
 
 This event is fired when a day is rendered inside the datepicker. Should return a string. Return 'disabled' to disable the day from being selected.
 
+### iconPrev
+
+String. Default: 'icon-arrow-left'
+
+The icon-font class for the Prev button
+(Markup counterpart: data-icon-prev)
+
+### iconNext
+
+String. Default: 'icon-arrow-right'
+
+The icon-font class for the Next button
+(Markup counterpart: data-icon-next)
+
+### triggerSelector
+
+String. Default: '.add-on .icon-th, .add-on .icon-time, .add-on .icon-calendar'
+
+Use it to specify a different jquery selector for the html element triggering the calendar.
+(Markup counterpart: data-trigger-selector)
+
+### resetSelector
+
+String. Default: '.add-on .icon-remove'
+
+Use it to specify a different jquery selector for the html element clearing the date input field.
+(Markup counterpart: data-reset-selector)
+
+
 ```javascript
 $('#date-end')
     .datetimepicker({
@@ -309,6 +354,40 @@ Format as component with reset button to clear the input field.
     <input class="span2" size="16" type="text" value="12-02-2012">
     <span class="add-on"><i class="icon-remove"></i></span>
     <span class="add-on"><i class="icon-th"></i></span>
+</div>
+```
+
+Format as component using Twitter Bootrap 3 and custom icons/selectors.
+
+```html
+<div class="input-group date col-lg-3" id="datetimepicker" 
+    data-date="12-02-2012 12:20" data-date-format="dd-mm-yyyy"
+    data-trigger-selector=".action-show-calendar"
+    data-icon-prev="glyphicon glyphicon-chevron-left" data-icon-next="glyphicon glyphicon-chevron-right"
+    >
+    <input type="text" size="16" class="form-control" value="12-02-2012 12:20">
+    <span class="input-group-addon">
+        <i class="glyphicon glyphicon-time action-show-calendar"></i>
+    </span>
+</div>
+```
+
+Format as component with reset button (segmented buttons example) using Twitter Bootrap 3, custom icons and selectors.
+
+```html
+<div class="input-group date col-lg-3" id="datetimepicker" 
+    data-date="12-02-2012 21:10" data-date-format="dd-mm-yyyy hh:ii"
+    data-trigger-selector=".action-show-calendar" data-reset-selector=".action-reset-date"
+    >
+    <input type="text" size="16" class="form-control" value="12-02-2012 21:10">
+    <div class="input-group-btn">
+        <span class="btn btn-default">
+            <i class="glyphicon glyphicon-remove action-reset-date"></i>
+        </span>
+        <span class="btn btn-default">
+            <i class="glyphicon glyphicon-calendar action-show-calendar"></i>
+        </span>
+    </div>
 </div>
 ```
 

--- a/js/bootstrap-datetimepicker.js
+++ b/js/bootstrap-datetimepicker.js
@@ -34,6 +34,15 @@
 
 	var Datetimepicker = function(element, options) {
 		var that = this;
+		
+    	this.iconLeft = options.iconLeft || 'icon-arrow-left';
+    	this.iconRight = options.iconRight || 'icon-arrow-right';
+
+    	DPGlobal.template = DPGlobal.template.replace(/{iconLeft}/g, this.iconLeft);
+    	DPGlobal.template = DPGlobal.template.replace(/{iconRight}/g, this.iconRight);
+    	
+    	this.triggerSelector = options.triggerSelector || '.add-on .icon-th, .add-on .icon-time, .add-on .icon-calendar';
+    	this.resetSelector = options.resetSelector || '.add-on .icon-remove';    	
 
 		this.element = $(element);
 		this.language = options.language || this.element.data('date-language') || "en";
@@ -44,8 +53,8 @@
 		this.isInline = false;
 		this.isVisible = false;
 		this.isInput = this.element.is('input');
-		this.component = this.element.is('.date') ? this.element.find('.add-on .icon-th, .add-on .icon-time, .add-on .icon-calendar').parent() : false;
-		this.componentReset = this.element.is('.date') ? this.element.find('.add-on .icon-remove').parent() : false;
+		this.component = this.element.is('.date') ? this.element.find(this.triggerSelector).parent() : false;
+		this.componentReset = this.element.is('.date') ? this.element.find(this.resetSelector).parent() : false;
 		this.hasInput = this.component && this.element.find('input').length;
 		if (this.component && this.component.length === 0) {
 			this.component = false;
@@ -154,7 +163,7 @@
 		if (this.isRTL){
 			this.picker.addClass('datetimepicker-rtl');
 			this.picker.find('.prev i, .next i')
-						.toggleClass('icon-arrow-left icon-arrow-right');
+						.toggleClass(this.iconLeft + ' ' + this.iconRight);
 		}
 		$(document).on('mousedown', function (e) {
 			// Clicked outside the datetimepicker, hide it
@@ -1517,12 +1526,12 @@
 			return viewMode;
 		},
 		headTemplate: '<thead>'+
-							'<tr>'+
-								'<th class="prev"><i class="icon-arrow-left"/></th>'+
-								'<th colspan="5" class="switch"></th>'+
-								'<th class="next"><i class="icon-arrow-right"/></th>'+
-							'</tr>'+
-						'</thead>',
+						'<tr>'+
+							'<th class="prev"><i class="{iconLeft}"/></th>'+
+							'<th colspan="5" class="switch"></th>'+
+							'<th class="next"><i class="{iconRight}"/></th>'+
+						'</tr>'+
+			      	  '</thead>',
 		contTemplate: '<tbody><tr><td colspan="7"></td></tr></tbody>',
 		footTemplate: '<tfoot><tr><th colspan="7" class="today"></th></tr></tfoot>'
 	};

--- a/js/bootstrap-datetimepicker.js
+++ b/js/bootstrap-datetimepicker.js
@@ -40,8 +40,9 @@
     	this.iconPrev = options.iconPrev || this.element.data('icon-prev') || 'icon-arrow-left';
     	this.iconNext = options.iconNext || this.element.data('icon-next') || 'icon-arrow-right';
 
-    	DPGlobal.template = DPGlobal.template.replace(/{iconPrev}/g, this.iconPrev);
-    	DPGlobal.template = DPGlobal.template.replace(/{iconNext}/g, this.iconNext);
+    	this.template = DPGlobal.template;
+    	this.template = this.template.replace(/{iconPrev}/g, this.iconPrev);
+    	this.template = this.template.replace(/{iconNext}/g, this.iconNext);
     	
     	this.triggerSelector = options.triggerSelector || this.element.data('trigger-selector') || '.add-on .icon-th, .add-on .icon-time, .add-on .icon-calendar';
     	this.resetSelector = options.resetSelector || this.element.data('reset-selector') || '.add-on .icon-remove';    	
@@ -138,7 +139,7 @@
 			this.forceParse = this.element.data('date-force-parse');
 		}
 
-		this.picker = $(DPGlobal.template)
+		this.picker = $(this.template)
 							.appendTo(this.isInline ? this.element : 'body')
 							.on({
 								click: $.proxy(this.click, this),

--- a/js/bootstrap-datetimepicker.js
+++ b/js/bootstrap-datetimepicker.js
@@ -35,16 +35,17 @@
 	var Datetimepicker = function(element, options) {
 		var that = this;
 		
-    	this.iconLeft = options.iconLeft || 'icon-arrow-left';
-    	this.iconRight = options.iconRight || 'icon-arrow-right';
-
-    	DPGlobal.template = DPGlobal.template.replace(/{iconLeft}/g, this.iconLeft);
-    	DPGlobal.template = DPGlobal.template.replace(/{iconRight}/g, this.iconRight);
-    	
-    	this.triggerSelector = options.triggerSelector || '.add-on .icon-th, .add-on .icon-time, .add-on .icon-calendar';
-    	this.resetSelector = options.resetSelector || '.add-on .icon-remove';    	
-
 		this.element = $(element);
+
+    	this.iconPrev = options.iconPrev || this.element.data('icon-prev') || 'icon-arrow-left';
+    	this.iconNext = options.iconNext || this.element.data('icon-next') || 'icon-arrow-right';
+
+    	DPGlobal.template = DPGlobal.template.replace(/{iconPrev}/g, this.iconPrev);
+    	DPGlobal.template = DPGlobal.template.replace(/{iconNext}/g, this.iconNext);
+    	
+    	this.triggerSelector = options.triggerSelector || this.element.data('trigger-selector') || '.add-on .icon-th, .add-on .icon-time, .add-on .icon-calendar';
+    	this.resetSelector = options.resetSelector || this.element.data('reset-selector') || '.add-on .icon-remove';    	
+
 		this.language = options.language || this.element.data('date-language') || "en";
 		this.language = this.language in dates ? this.language : "en";
 		this.isRTL = dates[this.language].rtl || false;
@@ -163,7 +164,7 @@
 		if (this.isRTL){
 			this.picker.addClass('datetimepicker-rtl');
 			this.picker.find('.prev i, .next i')
-						.toggleClass(this.iconLeft + ' ' + this.iconRight);
+						.toggleClass(this.iconPrev + ' ' + this.iconNext);
 		}
 		$(document).on('mousedown', function (e) {
 			// Clicked outside the datetimepicker, hide it
@@ -1527,9 +1528,9 @@
 		},
 		headTemplate: '<thead>'+
 						'<tr>'+
-							'<th class="prev"><i class="{iconLeft}"/></th>'+
+							'<th class="prev"><i class="{iconPrev}"/></th>'+
 							'<th colspan="5" class="switch"></th>'+
-							'<th class="next"><i class="{iconRight}"/></th>'+
+							'<th class="next"><i class="{iconNext}"/></th>'+
 						'</tr>'+
 			      	  '</thead>',
 		contTemplate: '<tbody><tr><td colspan="7"></td></tr></tbody>',


### PR DESCRIPTION
Allowing custom icons...

Trigger/reset elements can now be identified not only by icon but by any html attribute such as data-datepicker-action="trigger", data-datepicker-action="reset", different icon class, html id, etc.

just specify them as js options

triggerSelector
resetSelector
iconLeft
iconRight