### PR TITLE
making sure that we ignore leading and trailing spaces

### DIFF
--- a/js/bootstrap-datetimepicker.js
+++ b/js/bootstrap-datetimepicker.js
@@ -459,6 +459,9 @@
 				fromArgs = true;
 			} else {
 				date = this.element.data('date') || (this.isInput ? this.element.val() : this.element.find('input').val()) || this.initialDate;
+				if (typeof date == 'string' || date instanceof String) {
+				  date = date.replace(/^\s+|\s+$/g,'');
+				}
 			}
 
 			if (!date) {

--- a/tests/suites/formats.js
+++ b/tests/suites/formats.js
@@ -237,3 +237,11 @@ test('Invalid formats are force-parsed into a valid date on tab', patch_date(fun
 
     equal(this.input.val(), '56-September-30');
 }));
+
+test('Untrimmed datetime value', patch_date(function(Date){
+  this.input
+      .val('2012-03-05 ')
+      .datetimepicker({format: 'yyyy-mm-dd hh:ii'})
+      .datetimepicker('setValue');
+  equal(this.input.val(), '2012-03-05 00:00');
+}));


### PR DESCRIPTION
Provided format: `yyyy-mm-dd hh:ii` and input value: `2013-10-09` (note the trailing space) will set date to `1899-12-31 00:00` instead of expected `2013-10-09 00:00`. This pull request fixes this.
