### PR TITLE
When parsing short dates, ignore casing

### DIFF
--- a/js/bootstrap-datetimepicker.js
+++ b/js/bootstrap-datetimepicker.js
@@ -1439,7 +1439,7 @@
 								filtered = $(dates[language].monthsShort).filter(function () {
 									var m = this.slice(0, parts[i].length),
 										p = parts[i].slice(0, m.length);
-									return m == p;
+									return m.toLowerCase() == p.toLowerCase();
 								});
 								val = $.inArray(filtered[0], dates[language].monthsShort) + 1;
 								break;


### PR DESCRIPTION
At the moment, if you are using date format "dd M yyyy", if the user types a date their date won't be parsed correctly unless they adhere to the correct casing of the month. E.g. "21 Feb 2015" will be parsed correctly, but "21 feb 2015" will not. 

This lowercases both sides of the comparison in the filter so both types can be parsed and displayed with the preferred capitalisation. 
