### PR TITLE
Fixed formatViewType 'time' for languages without meridiem

### DIFF
--- a/js/bootstrap-datetimepicker.js
+++ b/js/bootstrap-datetimepicker.js
@@ -526,9 +526,9 @@
 				var minutesDisplay = (minutes < 10 ? '0' : '') + minutes;
 				var meridianDisplay = dates[this.language].meridiem[hours < 12 ? 0 : 1];
 				this.picker.find('.datetimepicker-hours thead th:eq(1)')
-					.text(hoursDisplay + ':' + minutesDisplay + ' ' + meridianDisplay.toUpperCase());
+					.text(hoursDisplay + ':' + minutesDisplay + ' ' + (meridianDisplay ? meridianDisplay.toUpperCase() : ''));
 				this.picker.find('.datetimepicker-minutes thead th:eq(1)')
-					.text(hoursDisplay + ':' + minutesDisplay + ' ' + meridianDisplay.toUpperCase());
+					.text(hoursDisplay + ':' + minutesDisplay + ' ' + (meridianDisplay ? meridianDisplay.toUpperCase() : ''));
 			} else {
 				this.picker.find('.datetimepicker-hours thead th:eq(1)')
 					.text(dayMonth + ' ' + dates[this.language].months[month] + ' ' + year);


### PR DESCRIPTION
Fixed formatViewType 'time' for languages without meridiem

E.g.: bootstrap-datetimepicker.es.js has meridiem: []
that caused this error:

Uncaught TypeError: Cannot call method 'toUpperCase' of undefined

Because meridianDisplay is undefined for some languages.
