### PR TITLE
Corrected the lang name for korea

### DIFF
--- a/js/locales/bootstrap-datetimepicker.ko.js
+++ b/js/locales/bootstrap-datetimepicker.ko.js
@@ -4,7 +4,7 @@
  * Baekjoon Choi <http://github.com/Baekjoon>
  */
 ;(function($){
-	$.fn.datetimepicker.dates['kr'] = {
+	$.fn.datetimepicker.dates['ko'] = {
 		days: ["일요일", "월요일", "화요일", "수요일", "목요일", "금요일", "토요일", "일요일"],
 		daysShort: ["일", "월", "화", "수", "목", "금", "토", "일"],
 		daysMin: ["일", "월", "화", "수", "목", "금", "토", "일"],


### PR DESCRIPTION
The lang code for Korea is: ko
http://www.lingoes.net/en/translator/langcode.htm

(Kr is county code.)
You could use ko-KR and ko-KP but I don't think it is required in this case.
