### PR TITLE
Font-awesome + Incorrectly enabled month

### DIFF
--- a/README.md
+++ b/README.md
@@ -291,6 +291,12 @@ $('#date-end')
     });
 ```
 
+### fontAwesome
+
+Boolean. Default: false
+
+If true, [Font Awesome](http://fontawesome.io/) will be used.
+
 ## Markup
 
 Format as component.
@@ -349,7 +355,7 @@ $('#datetimepicker').datetimepicker('hide');
 
 ### update
 
-Arguments: 
+Arguments:
 
 * currentDate (Date).
 
@@ -490,11 +496,11 @@ When the picker is visible, enter will simply hide it.  When the picker is not v
 
 ## Mouse Wheel View Navigation
 
-In order to make this plugin easier to set different part of date time, mouse wheel has been used to navigate through different views. Scroll up your mouse wheel to navigate to the decade year view. Scroll down will lead to the minute view. 
+In order to make this plugin easier to set different part of date time, mouse wheel has been used to navigate through different views. Scroll up your mouse wheel to navigate to the decade year view. Scroll down will lead to the minute view.
 
 ### Dependency
 
-To enalbe this feature. [jQuery Mouse Wheel Plugin](https://github.com/brandonaaron/jquery-mousewheel) must be included before using this feature. 
+To enalbe this feature. [jQuery Mouse Wheel Plugin](https://github.com/brandonaaron/jquery-mousewheel) must be included before using this feature.
 
 ### Options
 
@@ -522,7 +528,7 @@ The recommended value for viewSelect option is 4 when this feature is enable. Th
 
 ### Feature Demo
 
-A simple [Demo](http://lyonlai.github.io/bootstrap-datetimepicker/demo.html) page is given to show it's simple idea. 
+A simple [Demo](http://lyonlai.github.io/bootstrap-datetimepicker/demo.html) page is given to show it's simple idea.
 
 ## I18N
 

--- a/js/bootstrap-datetimepicker.js
+++ b/js/bootstrap-datetimepicker.js
@@ -61,8 +61,8 @@
 
 		this.bootcssVer = this.isInput ? (this.element.is('.form-control') ? 3 : 2) : ( this.bootcssVer = this.element.is('.input-group') ? 3 : 2 );
 
-		this.component = this.element.is('.date') ? ( this.bootcssVer == 3 ? this.element.find('.input-group-addon .glyphicon-th, .input-group-addon .glyphicon-time, .input-group-addon .glyphicon-calendar .fa-calendar .fa-clock-o').parent() : this.element.find('.add-on .icon-th, .add-on .icon-time, .add-on .icon-calendar').parent()) : false;
-		this.componentReset = this.element.is('.date') ? ( this.bootcssVer == 3 ? this.element.find('.input-group-addon .glyphicon-remove .fa-times').parent() : this.element.find('.add-on .icon-remove').parent()) : false;
+		this.component = this.element.is('.date') ? ( this.bootcssVer == 3 ? this.element.find('.input-group-addon .glyphicon-th, .input-group-addon .glyphicon-time, .input-group-addon .glyphicon-calendar .fa-calendar .fa-clock-o').parent() : this.element.find('.add-on .icon-th, .add-on .icon-time, .add-on .icon-calendar .fa-calendar .fa-clock-o').parent()) : false;
+		this.componentReset = this.element.is('.date') ? ( this.bootcssVer == 3 ? this.element.find('.input-group-addon .glyphicon-remove .fa-times').parent() : this.element.find('.add-on .icon-remove .fa-times').parent()) : false;
 		this.hasInput = this.component && this.element.find('input').length;
 		if (this.component && this.component.length === 0) {
 			this.component = false;
@@ -75,8 +75,8 @@
 		this.initialDate = options.initialDate || new Date();
 
 		this.icons = {
-			leftArrow: this.bootcssVer === 3 ? (this.fontAwesome ? 'fa-arrow-left' : 'glyphicon-arrow-left') : 'icon-arrow-left',
-			rightArrow: this.bootcssVer === 3 ? (this.fontAwesome ? 'fa-arrow-right' : 'glyphicon-arrow-right') : 'icon-arrow-right'
+			leftArrow: this.fontAwesome ? 'fa-arrow-left' : (this.bootcssVer === 3 ? 'glyphicon-arrow-left' : 'icon-arrow-left'),
+			rightArrow: this.fontAwesome ? 'fa-arrow-right' : (this.bootcssVer === 3 ? 'glyphicon-arrow-right' : 'icon-arrow-right')
 		};
 		this.icontype = this.fontAwesome ? 'fa' : 'glyphicon';
 


### PR DESCRIPTION
Added support for font-awesome that can be enabled in the options (disabled by default). It then adds/removes font-awesome classes instead of glyphicon ones.

I also fixed a small issue causing some months before the startDate to be enabled while they should not be (e.g. startDate was set to 28-06-2014 19:30, but April and May were enabled.
