### PR TITLE
Fix for prev/next arrow not working with BS3

### DIFF
--- a/css/bootstrap-datetimepicker.css
+++ b/css/bootstrap-datetimepicker.css
@@ -395,6 +395,10 @@
 	width: 145px;
 }
 
+.datetimepicker th span.glyphicon {
+	pointer-events: none;
+}
+
 .datetimepicker thead tr:first-child th,
 .datetimepicker tfoot tr:first-child th {
 	cursor: pointer;


### PR DESCRIPTION
Right now clicking exactly on prev/next arrow closes datetimepicker popup instead of doing what is expected.

This css fix causes click events to pass through left/right glyphicon to parent th.prev/th.next so that the proper click event is triggered.

This should fix #279.
