### PR TITLE
add 'old' variable define

### DIFF
--- a/js/bootstrap-datetimepicker.js
+++ b/js/bootstrap-datetimepicker.js
@@ -1303,6 +1303,7 @@
 		}
 	};
 
+	var old = $.fn.datetimepicker;
 	$.fn.datetimepicker = function (option) {
 		var args = Array.apply(null, arguments);
 		args.shift();


### PR DESCRIPTION
invoke $.fn.datetimepicker.noConflict error 'Uncaught ReferenceError: old is not defined', forgot old variable define
