### PR TITLE
Fix dateUTC from Date object

### DIFF
--- a/js/bootstrap-datetimepicker.js
+++ b/js/bootstrap-datetimepicker.js
@@ -1414,7 +1414,7 @@
 		},
 		parseDate:        function (date, format, language, type) {
 			if (date instanceof Date) {
-				var dateUTC = new Date(date.valueOf() - date.getTimezoneOffset() * 60000);
+				var dateUTC = new Date(date.valueOf() + date.getTimezoneOffset() * 60000);
 				dateUTC.setMilliseconds(0);
 				return dateUTC;
 			}


### PR DESCRIPTION
I think need an operation of addition, because the time zone already contains the arithmetic sign

new Date(1409315031000 -14400000) = Date {Fri Aug 29 2014 12:23:51 GMT+0400 (MSK)}

new Date(date - date.getTimezoneOffset() * 60000) = Date {Fri Aug 29 2014 20:23:51 GMT+0400 (MSK)}

new Date(date.valueOf() + (date.getTimezoneOffset() * 60000)) = Date {Fri Aug 29 2014 12:23:51 GMT+0400 (MSK)}

date.valueOf()	= 1409315031000
date.getTimezoneOffset() * 60000  = -14400000
date.getTimezoneOffset() = -240

Run `new Date('2014-08-29T08:23:51-04:00')` created  `Date {Fri Aug 29 2014 16:23:51 GMT+0400 (MSK)}` in my time zone.

Date {Fri Aug 29 2014 16:23:51 GMT+0400} = Date {Fri Aug 29 2014 12:23:51 GMT+0000} // true
Date {Fri Aug 29 2014 16:23:51 GMT+0400} = Date {Fri Aug 29 2014 20:23:51 GMT+0000} // false