### PR TITLE
Update bootstrap-datetimepicker.js

### DIFF
--- a/js/bootstrap-datetimepicker.js
+++ b/js/bootstrap-datetimepicker.js
@@ -1452,7 +1452,7 @@
 				}
 				return UTCDate(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate(), date.getUTCHours(), date.getUTCMinutes(), date.getUTCSeconds(), 0);
 			}
-			var parts = date && date.match(this.nonpunctuation) || [],
+			var parts = date && date.toString().match(this.nonpunctuation) || [],
 				date = new Date(0, 0, 0, 0, 0, 0, 0),
 				parsed = {},
 				setters_order = ['hh', 'h', 'ii', 'i', 'ss', 's', 'yyyy', 'yy', 'M', 'MM', 'm', 'mm', 'D', 'DD', 'd', 'dd', 'H', 'HH', 'p', 'P'],


### PR DESCRIPTION
fix parts parser in case of date as number (i.e. year picker only)

E.g.:

$('.year-picker', element).datetimepicker({
                format: "yyyy",
                weekStart: 1,
                todayBtn: true,
                autoclose: true,
                todayHighlight: true,
                startView: 4,
                minView: 4,
                maxView: 4,
                forceParse: true,
                language: App.language
            });

Will now work if we use only years
