### PR TITLE
Fix default format for fr locale 

### DIFF
--- a/js/locales/bootstrap-datetimepicker.fr.js
+++ b/js/locales/bootstrap-datetimepicker.fr.js
@@ -13,6 +13,6 @@
 		suffix: [],
 		meridiem: ["am", "pm"],
 		weekStart: 1,
-		format: "dd/mm/yyyy"
+		format: "dd/mm/yyyy hh:ii"
 	};
 }(jQuery));


### PR DESCRIPTION
Most of the locales use a `format` option that displays a complete datetime (e.g., `yyyy-mm-dd hh:ii`) by default. Alas, the french locale just displays a date.