### PR TITLE
Fix #344 - n+2 month is highlighted in some situation

### DIFF
--- a/js/bootstrap-datetimepicker.js
+++ b/js/bootstrap-datetimepicker.js
@@ -715,7 +715,9 @@
 				.find('span').removeClass('active');
 			if (currentYear == year) {
 				// getUTCMonths() returns 0 based, and we need to select the next one
-				months.eq(this.date.getUTCMonth() + 2).addClass('active');
+                // To cater bootstrap 2 we don't need to select the next one
+                var offset = months.length - 12;
+				months.eq(this.date.getUTCMonth() + offset).addClass('active');
 			}
 			if (year < startYear || year > endYear) {
 				months.addClass('disabled');

--- a/tests/suites/component.js
+++ b/tests/suites/component.js
@@ -8,7 +8,7 @@ module('Component', {
                         .datetimepicker({format: "dd-mm-yyyy", viewSelect: 2});
         this.input = this.component.find('input');
         this.addon = this.component.find('.input-group-addon');
-        this.dp = this.component.data('datetimepicker')
+        this.dp = this.component.data('datetimepicker');
         this.picker = this.dp.picker;
     },
     teardown: function(){
@@ -154,4 +154,26 @@ test('Selecting date resets viewDate and date', function(){
     // Re-rendered on click
     target = this.picker.find('.datetimepicker-days tbody td:first');
     equal(target.text(), '29'); // Should be Jan 29
+});
+
+test('Highlight in month', function() {
+    // custom setup for specifically bootstrap 2
+    var component = $('<div class="input-group date" id="datetimepicker">' +
+                             '<input size="16" type="text" value="12-02-2012" readonly>' +
+                             '<span class="input-group-addon"><span class="glyphicon glyphicon-th"></span></span>' +
+                             '</div>')
+        .appendTo('#qunit-fixture')
+        .datetimepicker({format: "dd-mm-yyyy", bootcssVer: 2}),
+        addon = component.find('.input-group-addon'),
+        picker = component.data('datetimepicker').picker;
+    addon.click();
+
+    equal(picker.find('.datetimepicker-months .month.active').text(), 'Feb');
+
+    picker.remove();
+
+    // test bootstrap 3 as well
+    this.addon.click();
+    equal(this.picker.find('.datetimepicker-months .month.active').text(), 'Feb');
+
 });


### PR DESCRIPTION
When the library thinks bootstrap 2 is used, the selected month + 2 will be highlight.
Fixed by calculate offset such that minimal change is done and minimal impact will be incurred.
Test is included