### PR TITLE
fix the highlight month view problem. When choose month X,then month X+2 is highlighted.

### DIFF
--- a/js/bootstrap-datetimepicker.js
+++ b/js/bootstrap-datetimepicker.js
@@ -715,7 +715,8 @@
 				.find('span').removeClass('active');
 			if (currentYear == year) {
 				// getUTCMonths() returns 0 based, and we need to select the next one
-				months.eq(this.date.getUTCMonth() + 2).addClass('active');
+				// the months is already 1 based no more calc need
+				months.eq(this.date.getUTCMonth()).addClass('active');
 			}
 			if (year < startYear || year > endYear) {
 				months.addClass('disabled');


### PR DESCRIPTION
When I set the datetimepicker option startView 3(the month view.) then the month highlight in a wrong way. I choose month April then the month June is highlighted, choose month december ,no month is highlight.
I fix the code like above, problems gone.
This problem also can be seen when use other startView like 2(the day view) and to change the month .