### PR TITLE
Autoprefixer: Gradient has outdated direction syntax.

### DIFF
--- a/less/datetimepicker.less
+++ b/less/datetimepicker.less
@@ -243,7 +243,7 @@
     background-image: -webkit-gradient(linear, 0 0, 0 100%, from(#fdd49a), to(#fdf59a));
     background-image: -webkit-linear-gradient(top, #fdd49a, #fdf59a);
     background-image: -o-linear-gradient(top, #fdd49a, #fdf59a);
-    background-image: linear-gradient(top, #fdd49a, #fdf59a);
+    background-image: linear-gradient(to bottom, #fdd49a, #fdf59a);
     background-repeat: repeat-x;
     filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#fdd49a', endColorstr='#fdf59a', GradientType=0);
     border-color: #fdf59a #fdf59a #fbed50;
@@ -292,7 +292,7 @@
     background-image: -webkit-gradient(linear, 0 0, 0 100%, from(#0088cc), to(#0044cc));
     background-image: -webkit-linear-gradient(top, #0088cc, #0044cc);
     background-image: -o-linear-gradient(top, #0088cc, #0044cc);
-    background-image: linear-gradient(top, #0088cc, #0044cc);
+    background-image: linear-gradient(to bottom, #0088cc, #0044cc);
     background-repeat: repeat-x;
     filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#0088cc', endColorstr='#0044cc', GradientType=0);
     border-color: #0044cc #0044cc #002a80;
@@ -358,7 +358,7 @@
     background-image: -webkit-gradient(linear, 0 0, 0 100%, from(#0088cc), to(#0044cc));
     background-image: -webkit-linear-gradient(top, #0088cc, #0044cc);
     background-image: -o-linear-gradient(top, #0088cc, #0044cc);
-    background-image: linear-gradient(top, #0088cc, #0044cc);
+    background-image: linear-gradient(to bottom, #0088cc, #0044cc);
     background-repeat: repeat-x;
     filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#0088cc', endColorstr='#0044cc', GradientType=0);
     border-color: #0044cc #0044cc #002a80;


### PR DESCRIPTION
This is caused by a change in the W3C standard of `linear-gradient` where `top` should be `to bottom` for clarity reasons.