### PR TITLE
add language fallback support

### DIFF
--- a/js/bootstrap-datetimepicker.js
+++ b/js/bootstrap-datetimepicker.js
@@ -74,6 +74,7 @@
     this.container = options.container || 'body';
 
     this.language = options.language || this.element.data('date-language') || 'en';
+    this.language = this.language in dates ? this.language : this.language.split('-')[0]; // fr-CA fallback to fr
     this.language = this.language in dates ? this.language : 'en';
     this.isRTL = dates[this.language].rtl || false;
     this.formatType = options.formatType || this.element.data('format-type') || 'standard';


### PR DESCRIPTION
If a language code ``fr-CA`` cannot be found in supported locales, try ``fr`` first before fallback to ``en``.