### PR TITLE
fixed endDate bug

### DIFF
--- a/js/bootstrap-datetimepicker.js
+++ b/js/bootstrap-datetimepicker.js
@@ -753,7 +753,7 @@
         months.slice(0, startMonth + 1).addClass('disabled');
       }
       if (year == endYear) {
-        months.slice(endMonth).addClass('disabled');
+        months.slice(endMonth + 2).addClass('disabled');
       }
 
       html = '';


### PR DESCRIPTION
#endDate option was error, disabled month less 2

## code:

```
$('#beginTime').datetimepicker({
    format: 'yyyy-mm-dd hh:ii:ss',
    endDate: '2015-09-10 12:23:12'
)
```

endDate specify endMonth is Sep,but Aug and Sep was disabled


## fixed:

wrong code:
```
755| if (year == endYear) {
756|     months.slice(endMonth).addClass('disabled');
767| }
```

right code:
```
755| if (year == endYear) {
756|     months.slice(endMonth + 2).addClass('disabled');
767| }
```