### PR TITLE
Fix positioning issue for datetimepicker dropdown

### DIFF
--- a/js/bootstrap-datetimepicker.js
+++ b/js/bootstrap-datetimepicker.js
@@ -515,9 +515,10 @@
         left = offset.left;
       }
 
-      if(left+220 > document.body.clientWidth){
-                  left = document.body.clientWidth-220;
-              }
+      var bodyWidth = document.body.clientWidth || window.innerWidth;
+      if (left + 220 > bodyWidth) {
+        left = bodyWidth - 220;
+      }
 
       if (this.pickerPosition == 'top-left' || this.pickerPosition == 'top-right') {
         top = offset.top - this.picker.outerHeight();


### PR DESCRIPTION
Fixed issue where document.body.clientWidth was 0 which caused picker to render off-screen when datetimepicker is shown in a modal and 'overflow:hidden' is specified. Fixed to ensure that a width is always returned so the left position of the picker is calculated correctly.