### PR TITLE
Fix date returned by changeDate event

### DIFF
--- a/js/bootstrap-datetimepicker.js
+++ b/js/bootstrap-datetimepicker.js
@@ -1082,7 +1082,7 @@
       }
       this.element.trigger({
         type: 'changeDate',
-        date: this.date
+        date: this.getDate()
       });
       if(date == null)
         this.date = this.viewDate;
@@ -1287,7 +1287,7 @@
         }
         this.element.trigger({
           type: 'changeDate',
-          date: this.date
+          date: this.getDate()
         });
       }
     },


### PR DESCRIPTION
The event object's date property should be equal
to the date selected by the user.

Fixes issues #134, #122 #57 