### PR TITLE
Show correct months on year view when specifying endDate

### DIFF
--- a/js/bootstrap-datetimepicker.js
+++ b/js/bootstrap-datetimepicker.js
@@ -797,7 +797,7 @@
         months.slice(0, startMonth + 1).addClass('disabled');
       }
       if (year == endYear) {
-        months.slice(endMonth).addClass('disabled');
+        months.slice(endMonth + 2).addClass('disabled');
       }
 
       html = '';


### PR DESCRIPTION
On viewing the year display of the datepicker after specifying the endDate the current month and the month prior from the date specified by the endDate are disabled. This change removes the disabled class as both should be selectable on the year view due to being before the specified endDate.
