### PR TITLE
fix #518

### DIFF
--- a/build/build_standalone.less
+++ b/build/build_standalone.less
@@ -29,7 +29,7 @@
 
 // The dropdown menu (ul)
 // ----------------------
-.datepicker.dropdown-menu {
+.datetimepicker.dropdown-menu {
   position: absolute;
   top: 100%;
   left: 0;
@@ -62,7 +62,7 @@
 
 // Alternative arrows
 // May require `charset="UTF-8"` in your `<link>` tag
-.datepicker {
+.datetimepicker {
   .prev, .next {font-style:normal;}
   .prev:after {content:"«";}
   .next:after {content:"»";}


### PR DESCRIPTION
proper .datetimepicker selector for fallback text-arrows to work in standalone context