### PR TITLE
support `Z` option which will display timezone name or default to 'EDT'

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,7 @@ The date format, combination of p, P, h, hh, i, ii, s, ss, d, dd, m, mm, M, MM, 
  * yy : two digit representation of a year
  * yyyy : full numeric representation of a year, 4 digits
  * t : unix epoch timestamp
+ * Z : abbreviated timezone name
 
 ### weekStart
 
@@ -296,6 +297,23 @@ You can initialize the viewer with a date. By default it's now, so you can speci
 Number. Default: undefined
 
 zIndex value is being automatically calculated based on the DOM tree, where we seek the highest value. To skip this process you can set the value manually.
+
+### timezone
+
+String. Default: Clients current timezone abbreviated name
+
+You can allow the viewer to display the date along with the given timezone. Note that this has to be used in conjunction with the `Z` format option. Example below: 
+
+
+```javascript
+$('#date-end').datetimepicker({
+        format: 'yyyy-mm-dd hh:ii P Z'
+        timezone: 'GMT'
+    });
+```
+
+![](http://s32.postimg.org/55x4fud05/Screen_Shot_2016_05_17_at_5_43_34_PM.png)
+
 
 ### onRender
 

--- a/tests/suites/formats.js
+++ b/tests/suites/formats.js
@@ -245,3 +245,12 @@ test('Untrimmed datetime value', patch_date(function(Date){
       .datetimepicker('setValue');
   equal(this.input.val(), '2012-03-05 00:00');
 }));
+
+
+test('With timezone option', patch_date(function(Date){
+  this.input
+      .val('2012-03-05')
+      .datetimepicker({format: 'yyyy-mm-dd hh:ii P Z'})
+      .datetimepicker('setValue');
+  equal(this.input.val(), '2012-03-05 00:00 AM UTC');
+}));


### PR DESCRIPTION
Enable bootstrap-datetimepicker to support and display timezone name in the input field. How it works: 


```javascript
this.$('input').datetimepicker({
  autoclose: true,
  forceParse: true,
  format: 'dd MM yyyy - HH:ii P Z',
  minuteStep: 15,
  showMeridian: true,
  todayHighlight: true,
  timezone: 'GMT'
});
```

![image](https://cloud.githubusercontent.com/assets/870447/15339382/3b0f60cc-1c52-11e6-89d2-12c32f899db5.png)
