### PR TITLE
Fix incorrectly disabled months with bootcssVer: 3

### DIFF
--- a/js/bootstrap-datetimepicker.js
+++ b/js/bootstrap-datetimepicker.js
@@ -783,7 +783,7 @@
       var currentYear = this.date.getUTCFullYear();
       var months = this.setTitle('.datetimepicker-months', year)
         .end()
-        .find('span').removeClass('active');
+        .find('span.month').removeClass('active');
       if (currentYear == year) {
         // getUTCMonths() returns 0 based, and we need to select the next one
         // To cater bootstrap 2 we don't need to select the next one


### PR DESCRIPTION
When using bootstrap 3, glyphicons are _span_ instead of _i_, leading to an incorrect selector for months.
