### PR TITLE
Ensure we are supporting all browsers for timezone abbreviation

### DIFF
--- a/js/bootstrap-datetimepicker.js
+++ b/js/bootstrap-datetimepicker.js
@@ -63,6 +63,24 @@
     return isFixed;
   }
 
+  // Add timezone abbreviation support for ie6+, Chrome, Firefox
+  function timeZoneAbbreviation() {
+    var abbreviation, date, formattedStr, i, len, matchedStrings, ref, str;
+    date = (new Date).toString();
+    formattedStr = ((ref = date.split('(')[1]) != null ? ref.slice(0, -1) : void 0) || date.split(' ');
+    if (formattedStr instanceof Array) {
+      matchedStrings = [];
+      for (i = 0, len = formattedStr.length; i < len; i++) {
+        str = formattedStr[i];
+        if (abbreviation = (ref = str.match(/\b[A-Z]+\b/)) != null ? ref[0] : void 0) {
+          matchedStrings.push(abbreviation);
+        }
+      }
+      formattedStr = matchedStrings.pop();
+    }
+    return formattedStr;
+  };
+
   function UTCDate() {
     return new Date(Date.UTC.apply(Date, arguments));
   }
@@ -109,8 +127,7 @@
     this.initialDate = options.initialDate || new Date();
     this.zIndex = options.zIndex || this.element.data('z-index') || undefined;
     this.title = typeof options.title === 'undefined' ? false : options.title;
-    this.defaultTimeZone = (new Date).toString().split('(')[1].slice(0, -1);
-    this.timezone = options.timezone || this.defaultTimeZone;
+    this.timezone = options.timezone || timeZoneAbbreviation();
 
     this.icons = {
       leftArrow: this.fontAwesome ? 'fa-arrow-left' : (this.bootcssVer === 3 ? 'glyphicon-arrow-left' : 'icon-arrow-left'),


### PR DESCRIPTION
The issue at hand was that browsers on different OS's return different formats when running `(new Date).toString()`. As an example IE10 and below does not support the current implementation as shown here: 

Windows IE10 and below does not support `(new Date).toString().split('(')[1].slice(0, -1);` 

![](http://g.recordit.co/omSXsdrEBX.gif)

With this PR it now ensures that this support is maintained as shown here: 

![](http://g.recordit.co/QZd49Du492.gif)

fixes https://github.com/smalot/bootstrap-datetimepicker/pull/530
fixes https://github.com/smalot/bootstrap-datetimepicker/pull/539
fixes https://github.com/smalot/bootstrap-datetimepicker/pull/576
fixes #549 
fixes #574
fixes #591
