### PR TITLE
Fix exception thrown after clearing value using built in clear button

### DIFF
--- a/js/bootstrap-datetimepicker.js
+++ b/js/bootstrap-datetimepicker.js
@@ -388,6 +388,9 @@
 
     getDate: function () {
       var d = this.getUTCDate();
+      if (d === null) {
+        return null;
+      }
       return new Date(d.getTime() + (d.getTimezoneOffset() * 60000));
     },
 


### PR DESCRIPTION
When using the `clearBtn: true,` option, or the icon add-on in html, it would throw an error in `getDate`