### PR TITLE
Ensure when reinitialising `clsName` it is inside the while loop

### DIFF
--- a/js/bootstrap-datetimepicker.js
+++ b/js/bootstrap-datetimepicker.js
@@ -698,11 +698,12 @@
       nextMonth.setUTCDate(nextMonth.getUTCDate() + 42);
       nextMonth = nextMonth.valueOf();
       var html = [];
-      var clsName = this.onRender(prevMonth)
+      var clsName;
       while (prevMonth.valueOf() < nextMonth) {
         if (prevMonth.getUTCDay() == this.weekStart) {
           html.push('<tr>');
         }
+        clsName = this.onRender(prevMonth);
         if (prevMonth.getUTCFullYear() < year || (prevMonth.getUTCFullYear() == year && prevMonth.getUTCMonth() < month)) {
           clsName += ' old';
         } else if (prevMonth.getUTCFullYear() > year || (prevMonth.getUTCFullYear() == year && prevMonth.getUTCMonth() > month)) {


### PR DESCRIPTION
So it appears the cause of: 

![image](https://cloud.githubusercontent.com/assets/870447/21027146/73dc906a-bd87-11e6-99fa-3324dbd05677.png)

Correct me if I am wrong is that, we don't seem to be reinitialising the variable `clsName` back to an empty string which is what `this.onRender(prevMonth);` returns. With that said we should be reinitialising the `clsName` back to whatever `this.onRender(prevMonth);` returns _inside_ the while loop. 

cc @AuspeXeu for review