### PR TITLE
Correct header when using datetimepicker as 'timepicker'

### DIFF
--- a/js/bootstrap-datetimepicker.js
+++ b/js/bootstrap-datetimepicker.js
@@ -653,6 +653,8 @@
       });
     },
 
+    hour_minute: "^([0-9]|0[0-9]|1[0-9]|2[0-3]):[0-5][0-9]",
+
     update: function () {
       var date, fromArgs = false;
       if (arguments && arguments.length && (typeof arguments[0] === 'string' || arguments[0] instanceof Date)) {
@@ -668,6 +670,12 @@
       if (!date) {
         date = new Date();
         fromArgs = false;
+      }
+
+      if (typeof date === "string") {
+        if (new RegExp(this.hour_minute).test(date) || new RegExp(this.hour_minute + ":[0-5][0-9]").test(date)) {
+          date = this.getDate()
+        }
       }
 
       this.date = DPGlobal.parseDate(date, this.format, this.language, this.formatType, this.timezone);


### PR DESCRIPTION
Current issue at hand is if you use the datetimepicker as a timepicker, when the `#update` function is calls `parseDate` it doesn't have a correct date object and therefore doesn't parse it correctly which results in the date being: `1899-12-31`. 

* Add 'hour_minute' regex
* If date is a time format call #getDate() to ensure when parsedDate is
called it gracefully parse the date.

fixes: https://github.com/smalot/bootstrap-datetimepicker/issues/569
fixes: https://github.com/2amigos/yii2-date-picker-widget/issues/35

cc @AuspeXeu to review. 