### PR TITLE
Fix resetting of viewDate

### DIFF
--- a/js/bootstrap-datetimepicker.js
+++ b/js/bootstrap-datetimepicker.js
@@ -418,6 +418,7 @@
       this.picker.hide();
       $(window).off('resize', this.place);
       this.viewMode = this.startViewMode;
+      this.viewDate = new Date(this.date);
       this.showMode();
       if (!this.isInput) {
         $(document).off('mousedown', this.hide);
@@ -677,11 +678,11 @@
 
       if (fromArgs) this.setValue();
 
-      if (this.date < this.startDate) {
+      if (this.viewDate < this.startDate) {
         this.viewDate = new Date(this.startDate);
-      } else if (this.date > this.endDate) {
+      } else if (this.viewDate > this.endDate) {
         this.viewDate = new Date(this.endDate);
-      } else {
+      } else if(!this.viewDate){
         this.viewDate = new Date(this.date);
       }
       this.fill();


### PR DESCRIPTION
The `update` method will compare `viewDate` instead of `date` to correctly reset(or not) the `viewDate` attribute, `viewDate` will reset to `date` on the `hide` method. Fixes #617 