### PR TITLE
Jstelfox/implement209

### DIFF
--- a/js/bootstrap-datetimepicker.js
+++ b/js/bootstrap-datetimepicker.js
@@ -222,7 +222,7 @@
     if (this.isInline) {
       this.picker.addClass('datetimepicker-inline');
     } else {
-      this.picker.addClass('datetimepicker-dropdown-' + this.getAutoPosition() + ' dropdown-menu');
+      this.picker.addClass('datetimepicker-dropdown-' + this.getAutoPosition(true) + ' dropdown-menu');
     }
     if (this.isRTL) {
       this.picker.addClass('datetimepicker-rtl');
@@ -592,25 +592,46 @@
       this.updateNavArrows();
     },
 
-    getAutoPosition: function () { 
+    getAutoHorizonalPosition: function(inverse) {
         if (this.pickerPosition != 'auto') { 
             return this.pickerPosition; 
-        } 
+        }
+ 
+        var offset = this.component ? this.component.offset() : this.element.offset(); 
+        var pickerWidth = this.picker.outerWidth();
+        var pickerWidthWithMargin = this.picker.outerWidth(true);
+        var leftOverflow = $(window).width() - (offset.left + pickerWidthWithMargin + pickerWidth);
+
+        var side = leftOverflow < 0 ? 'left' : 'right';
+
+        var position = side;
+
+        if (!!inverse) {
+            position = side == 'left' ? 'right' : 'left'
+        }
+ 
+        return position;
+    },
+
+    getAutoVerticalPosition: function() {
+        if (this.pickerPosition != 'auto') { 
+            return this.pickerPosition; 
+        }
  
         var offset = this.component ? this.component.offset() : this.element.offset(); 
         var pickerHeight = this.picker.outerHeight(); 
         var pickerHeightWithMargin = this.picker.outerHeight(true); 
         var bottomOverflow = $(window).height() - (offset.top + pickerHeightWithMargin + pickerHeight); 
  
-        var prefix = bottomOverflow < 0 ? 'top' : 'bottom'; 
+        return bottomOverflow < 0 ? 'top' : 'bottom';
+    },
+
+    getAutoPosition: function (inverse) { 
+        if (this.pickerPosition != 'auto') { 
+            return this.pickerPosition; 
+        }
  
-        var pickerWidth = this.picker.outerWidth(); 
-        var pickerWidthWithMargin = this.picker.outerWidth(true); 
-        var leftOverflow = $(window).width() - (offset.left + pickerWidthWithMargin + pickerWidth); 
- 
-        var suffix = leftOverflow < 0 ? 'left' : 'right'; 
- 
-        return prefix + '-' + suffix; 
+        return this.getAutoVerticalPosition() + '-' + this.getAutoHorizonalPosition(inverse);
     },
 
     place: function () {

--- a/js/bootstrap-datetimepicker.js
+++ b/js/bootstrap-datetimepicker.js
@@ -104,7 +104,7 @@
     this.linkField = options.linkField || this.element.data('link-field') || false;
     this.linkFormat = DPGlobal.parseFormat(options.linkFormat || this.element.data('link-format') || DPGlobal.getDefaultFormat(this.formatType, 'link'), this.formatType);
     this.minuteStep = options.minuteStep || this.element.data('minute-step') || 5;
-    this.pickerPosition = options.pickerPosition || this.element.data('picker-position') || 'bottom-right';
+    this.pickerPosition = options.pickerPosition || this.element.data('picker-position') || 'auto';
     this.showMeridian = options.showMeridian || this.element.data('show-meridian') || false;
     this.initialDate = options.initialDate || new Date();
     this.zIndex = options.zIndex || this.element.data('z-index') || undefined;
@@ -222,7 +222,7 @@
     if (this.isInline) {
       this.picker.addClass('datetimepicker-inline');
     } else {
-      this.picker.addClass('datetimepicker-dropdown-' + this.pickerPosition + ' dropdown-menu');
+      this.picker.addClass('datetimepicker-dropdown-' + this.getAutoPosition() + ' dropdown-menu');
     }
     if (this.isRTL) {
       this.picker.addClass('datetimepicker-rtl');
@@ -592,6 +592,27 @@
       this.updateNavArrows();
     },
 
+    getAutoPosition: function () { 
+        if (this.pickerPosition != 'auto') { 
+            return this.pickerPosition; 
+        } 
+ 
+        var offset = this.component ? this.component.offset() : this.element.offset(); 
+        var pickerHeight = this.picker.outerHeight(); 
+        var pickerHeightWithMargin = this.picker.outerHeight(true); 
+        var bottomOverflow = $(window).height() - (offset.top + pickerHeightWithMargin + pickerHeight); 
+ 
+        var prefix = bottomOverflow < 0 ? 'top' : 'bottom'; 
+ 
+        var pickerWidth = this.picker.outerWidth(); 
+        var pickerWidthWithMargin = this.picker.outerWidth(true); 
+        var leftOverflow = $(window).width() - (offset.left + pickerWidthWithMargin + pickerWidth); 
+ 
+        var suffix = leftOverflow < 0 ? 'left' : 'right'; 
+ 
+        return prefix + '-' + suffix; 
+    },
+
     place: function () {
       if (this.isInline) return;
 
@@ -612,6 +633,10 @@
       } else {
         containerOffset = $(this.container).offset();
       }
+
+      if (this.pickerPosition == 'auto') { 
+          this.pickerPosition = this.getAutoPosition(); 
+      } 
 
       if (this.component) {
         offset = this.component.offset();


### PR DESCRIPTION
This should resolve #209.

My [first commit](https://github.com/smalot/bootstrap-datetimepicker/commit/7b26a08d17a17d00947adbd71b880022cb7c038b) should have been all that was needed to implement this.

However, I ran into an issue where left and right did not _always_ mean left or right respectively.

Ex:

If you look at the datepickers before this PR, they would have the css 'bottom-right'. However, the datepicker is created on the left hand side and the arrow is on the left.

Swapping the CSS to be 'bottom-left' moves the arrow to the right side. Moreover, the picker would be on the left, but the arrow on the right of the picker.

![top-left_is_top-right_bug](https://cloud.githubusercontent.com/assets/857362/24417345/e5a0a482-139c-11e7-8887-b171d191354f.png)
![top-left_is_top-right_bug2](https://cloud.githubusercontent.com/assets/857362/24417347/e61e72c2-139c-11e7-9645-085716108496.png)

I was worried about changing the CSS to seem more correct in this scenario. It may be a breaking change for many people using this library. Even if it seems correct.

Thus, [I wrote the class being applied](https://github.com/smalot/bootstrap-datetimepicker/commit/db4918ca3b4af5e912bce162102d5b9726cb1c5b) to be the inverse (left/right) of the actually picker's location.

This will ensure the picker and arrow appears on the same side.

I can open an issue to look into this if needed.

Testing:

- Ensure Date pickers near the bottom of the page do not go off screen and instead open above the input
- Ensure default positioning of all pickers and thier arrows are on the left side of an input
- Ensure default positioning of all pickers are on the bottom

