### PR TITLE
Fixed issue when using only time in html value attribute

### DIFF
--- a/js/bootstrap-datetimepicker.js
+++ b/js/bootstrap-datetimepicker.js
@@ -448,7 +448,7 @@
 
     getDate: function () {
       var d = this.getUTCDate();
-      if (d === null) {
+      if (d === null || typeof d === 'undefined') {
         return null;
       }
       return new Date(d.getTime() + (d.getTimezoneOffset() * 60000));


### PR DESCRIPTION
The getUTCDate() function returns undefined which is not accounted for in the if(d === null), more issue details on the issue can be found in issue #666

https://github.com/smalot/bootstrap-datetimepicker/issues/666